### PR TITLE
check: don't consider blank identifier as descriptive name

### DIFF
--- a/check/check.go
+++ b/check/check.go
@@ -664,7 +664,7 @@ func receivesExtractedArgs(sign *types.Signature, call *ssa.Call) bool {
 
 func paramDesc(i int, v *types.Var) string {
 	name := v.Name()
-	if name != "" {
+	if name != "" && name != "_" {
 		return name
 	}
 	return fmt.Sprintf("%d (%s)", i, v.Type().String())

--- a/check/testdata/ignoredrets.go
+++ b/check/testdata/ignoredrets.go
@@ -33,6 +33,16 @@ func SingleIgnoredNameUse() {
 	_ = singleIgnoredName()
 }
 
+func singleIgnoredUnderscore() (_ rune) {
+	doWork()
+	return '0'
+}
+
+func SingleIgnoredUnderscoreUse() {
+	singleIgnoredUnderscore()
+	_ = singleIgnoredUnderscore()
+}
+
 func allIgnored() (int, string) {
 	doWork()
 	return 2, "foo"

--- a/check/testdata/log
+++ b/check/testdata/log
@@ -5,10 +5,11 @@ testdata/extractparams.go:45:26: returnResultsOwn - result 0 (./testdata.FooType
 testdata/funclit.go:4:20: parent$1 - f is unused
 testdata/ignoredrets.go:5:22: singleIgnored - result 0 (rune) is never used
 testdata/ignoredrets.go:26:27: singleIgnoredName - result r is never used
-testdata/ignoredrets.go:36:20: allIgnored - result 0 (int) is never used
-testdata/ignoredrets.go:36:25: allIgnored - result 1 (string) is never used
-testdata/ignoredrets.go:46:26: someIgnored - result 1 (string) is never used
-testdata/ignoredrets.go:71:29: ignoredGoDefer - result 1 (string) is never used
+testdata/ignoredrets.go:36:33: singleIgnoredUnderscore - result 0 (rune) is never used
+testdata/ignoredrets.go:46:20: allIgnored - result 0 (int) is never used
+testdata/ignoredrets.go:46:25: allIgnored - result 1 (string) is never used
+testdata/ignoredrets.go:56:26: someIgnored - result 1 (string) is never used
+testdata/ignoredrets.go:81:29: ignoredGoDefer - result 1 (string) is never used
 testdata/main/main.go:3:19: OneUnused - b is unused
 testdata/methods.go:5:28: (FooType).oneUnused - a is unused
 testdata/names.go:3:18: regularName - f is unused

--- a/main.go
+++ b/main.go
@@ -15,7 +15,7 @@ import (
 )
 
 var (
-	algo     = flag.String("algo", "cha", `call graph construction algorithm (cha, rta).
+	algo = flag.String("algo", "cha", `call graph construction algorithm (cha, rta).
 in general, use cha for libraries, and rta for programs with main packages.`)
 	tests    = flag.Bool("tests", true, "include tests")
 	exported = flag.Bool("exported", false, "inspect exported functions")


### PR DESCRIPTION
Since the blank identifier (`_`) is not a descriptive and unique result name, don't consider it as such when describing the result. Treat it as if the name isn't there at all.

Fixes #25.