### PR TITLE
set exit code according to found warnings

### DIFF
--- a/main.go
+++ b/main.go
@@ -41,5 +41,7 @@ func main() {
 	for _, warn := range warns {
 		fmt.Println(warn)
 	}
-	os.Exit(len(warns))
+	if len(warns) > 0 {
+		os.Exit(2)
+	}
 }

--- a/main.go
+++ b/main.go
@@ -42,6 +42,6 @@ func main() {
 		fmt.Println(warn)
 	}
 	if len(warns) > 0 {
-		os.Exit(2)
+		os.Exit(1)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -41,4 +41,5 @@ func main() {
 	for _, warn := range warns {
 		fmt.Println(warn)
 	}
+	os.Exit(len(warns))
 }


### PR DESCRIPTION
Setting the exit > 0 if there are some warnings makes it easier to use in automated tests.