### PR TITLE
update golang.org/x/tools, fix panic with type params

### DIFF
--- a/check/check.go
+++ b/check/check.go
@@ -593,9 +593,13 @@ resLoop:
 			c.debug("  skip - no name or underscore name\n")
 			continue
 		}
-		if stdSizes.Sizeof(par.Type()) == 0 {
-			c.debug("  skip - zero size\n")
-			continue
+		t := par.Type()
+		// asking for the size of a type param would panic, as it is unknowable
+		if _, ok := t.(*types.TypeParam); !ok {
+			if stdSizes.Sizeof(par.Type()) == 0 {
+				c.debug("  skip - zero size\n")
+				continue
+			}
 		}
 		reason := "is unused"
 		constStr := c.alwaysReceivedConst(callSites, par, i)

--- a/go.mod
+++ b/go.mod
@@ -4,11 +4,11 @@ go 1.18
 
 require (
 	github.com/rogpeppe/go-internal v1.9.0
-	golang.org/x/tools v0.1.12
+	golang.org/x/tools v0.4.0
 )
 
 require (
 	github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e // indirect
-	golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 // indirect
-	golang.org/x/sys v0.0.0-20220919091848-fb04ddd9f9c8 // indirect
+	golang.org/x/mod v0.7.0 // indirect
+	golang.org/x/sys v0.3.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -2,9 +2,10 @@ github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e h1:aoZm08cpOy4WuID//EZDgc
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
-golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 h1:6zppjxzCulZykYSLyVDYbneBfbaBIQPYMevg0bEwv2s=
-golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
-golang.org/x/sys v0.0.0-20220919091848-fb04ddd9f9c8 h1:h+EGohizhe9XlX18rfpa8k8RAc5XyaeamM+0VHRd4lc=
-golang.org/x/sys v0.0.0-20220919091848-fb04ddd9f9c8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/tools v0.1.12 h1:VveCTK38A2rkS8ZqFY25HIDFscX5X9OoEhJd3quQmXU=
-golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc=
+golang.org/x/mod v0.7.0 h1:LapD9S96VoQRhi/GrNTqeBJFrUjs5UHCAtTlgwA5oZA=
+golang.org/x/mod v0.7.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
+golang.org/x/sync v0.1.0 h1:wsuoTGHzEhffawBOhz5CYhcrV4IdKZbEyZjBMuTp12o=
+golang.org/x/sys v0.3.0 h1:w8ZOecv6NaNa/zC8944JTU3vz4u6Lagfk4RPQxv92NQ=
+golang.org/x/sys v0.3.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/tools v0.4.0 h1:7mTAgkunk3fr4GAloyyCasadO6h9zSsQZbwvcaIciV4=
+golang.org/x/tools v0.4.0/go.mod h1:UE5sM2OK9E/d67R0ANs2xJizIymRP5gJU295PvKXxjQ=

--- a/testdata/script/typeparams.txtar
+++ b/testdata/script/typeparams.txtar
@@ -1,7 +1,10 @@
-# TODO: catch unusedGeneric.
-exec unparam .
+! exec unparam .
+cmp stderr stderr.golden
+cmp stdout stdout.golden
 
+-- stderr.golden --
 -- stdout.golden --
+foo.go:39:38: (Tuple[T1, T2]).unusedGeneric - t1 is unused
 -- go.mod --
 module testdata.tld/foo
 


### PR DESCRIPTION
When unparam is embedded into e.g. [golangci-lint](https://github.com/golangci/golangci-lint/issues/3426) and a newer golang.org/x/tools version is picked up, it can panic when analyzing generic code. In the version of tools unparam currently uses, it doesn't see generic functions at all. But in the updated version it does, and asking for the size of a type parameter panics, because it is unknown / unknowable.

Example code that will trigger this panic w/o the fix:
```go
package example

import (
    "context"
    "fmt"
    "time"
)

var RetryDelay = time.Minute

func RunWithRetries[T, U any](
	ctx context.Context,
	f func(ctx context.Context, value T) (U, error),
	value T,
) (U, error) {
	for {
		if result, err := f(ctx, value); err == nil {
			return result, nil
		} else {
			fmt.Printf("waiting %v to retry: %v\n", RetryDelay, err)
			delay := time.After(RetryDelay)
			select {
			case <-ctx.Done():
				return result, ctx.Err()
			case <-delay:
				// continue
			}
		}
	}
}
```