### PR TITLE
fix: extend support of parenthesized expression as receiver

### DIFF
--- a/check/check.go
+++ b/check/check.go
@@ -908,15 +908,20 @@ func recvPrefix(recv *ast.FieldList) string {
 		}
 		expr = star.X
 	}
+
+	return identName(expr)
+}
+
+func identName(expr ast.Expr) string {
 	switch expr := expr.(type) {
 	case *ast.Ident:
 		return expr.Name + "."
 	case *ast.IndexExpr:
-		return expr.X.(*ast.Ident).Name + "."
+		return identName(expr.X)
 	case *ast.ParenExpr:
-		return expr.X.(*ast.Ident).Name + "."
+		return identName(expr.X)
 	case *ast.IndexListExpr:
-		return expr.X.(*ast.Ident).Name + "."
+		return identName(expr.X)
 	default:
 		panic(fmt.Sprintf("unexpected receiver AST node: %T", expr))
 	}

--- a/testdata/script/parenthesized_expression.txtar
+++ b/testdata/script/parenthesized_expression.txtar
@@ -7,6 +7,7 @@ module testdata.tld/foo
 go 1.18
 -- stdout.golden --
 foo.go:7:37: (*FooType).multImplsMethod - a is unused
+foo.go:12:44: (*FooType).multImplsMethod2 - a is unused
 -- foo.go --
 package foo
 
@@ -15,6 +16,11 @@ var DoWork func()
 type FooType int
 
 func (f *(FooType)) multImplsMethod(a int) int64 {
+	DoWork()
+	return 3
+}
+
+func (f *((((FooType))))) multImplsMethod2(a int) int64 {
 	DoWork()
 	return 3
 }


### PR DESCRIPTION
Just for the completion of #78.
