### PR TITLE
chore: use oldstable and stable alias a Go version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.20.x, 1.21.x]
+        go-version: [oldstable, stable]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
@@ -17,7 +17,7 @@ jobs:
 
     # Static checks from this point forward. Only run on one Go version and on
     # Linux, since it's the fastest platform, and the tools behave the same.
-    - if: matrix.os == 'ubuntu-latest' && matrix.go-version == '1.21.x'
+    - if: matrix.os == 'ubuntu-latest' && matrix.go-version == 'stable'
       run: diff <(echo -n) <(gofmt -s -d .)
-    - if: matrix.os == 'ubuntu-latest' && matrix.go-version == '1.21.x'
+    - if: matrix.os == 'ubuntu-latest' && matrix.go-version == 'stable'
       run: go vet ./...


### PR DESCRIPTION
It allows the CI to automatically follow the "2 latest minor versions of Go" rule.

https://github.com/actions/setup-go?tab=readme-ov-file#using-stableoldstable-aliases