### PR TITLE
fix: resolve type alias (#85)

### DIFF
--- a/check/check.go
+++ b/check/check.go
@@ -411,7 +411,7 @@ func (c *Checker) addImplementing(named *types.Named, iface *types.Interface) {
 }
 
 func findNamed(typ types.Type) *types.Named {
-	switch typ := typ.(type) {
+	switch typ := types.Unalias(typ).(type) {
 	case *types.Pointer:
 		return findNamed(typ.Elem())
 	case *types.Named:

--- a/testdata/script/typealias.txtar
+++ b/testdata/script/typealias.txtar
@@ -1,0 +1,27 @@
+! exec unparam .
+cmp stderr stderr.golden
+cmp stdout stdout.golden
+
+-- stderr.golden --
+-- stdout.golden --
+foo.go:9:20: (Alias).bar - s is unused
+-- go.mod --
+module testdata.tld/foo
+
+go 1.18
+-- foo.go --
+package foo
+
+type A struct {
+	b struct{}
+}
+
+type Alias = A
+
+func (a Alias) bar(s string) {
+	_ = a.b // Needed for bar to not be considered a dummy implementation
+}
+
+func test() {
+	Alias{}.bar("")
+}


### PR DESCRIPTION
We had the same issue as #85.

Minimal reproducible example (same as the test case):

```go
package foo

type A struct {
	b struct{}
}

type Alias = A

func (a Alias) bar(s string) {
	_ = a.b // Needed for bar to not be considered a dummy implementation
}

func test() {
	Alias{}.bar("")
}
```

We debugged the code and found out that `findNamed(...`) does not resolve a `*types.Alias`. This PR fixes the bug. Also included is a test which panics when trying to run it without the changes contained in this PR. We're not sure if `go 1.18` is the correct value in the test case, it's just copied over from the other test cases. 

Let me know if this PR is the wrong approach (because I'm not familiar with the code base) or if something needs to change.
