### PR TITLE
Attempt to fix panic when used from golangci-lint

### DIFF
--- a/check/check.go
+++ b/check/check.go
@@ -624,7 +624,7 @@ func containsTypeParam(t types.Type) bool {
 	case *types.Struct:
 		nf := t.NumFields()
 		for i := 0; i < nf; i++ {
-			if containsTypeParam(t.Field(nf).Type()) {
+			if containsTypeParam(t.Field(i).Type()) {
 				return true
 			}
 		}


### PR DESCRIPTION
This line panics for me, so without really understanding the intent of the code, change it to what it looks like it obviously should be doing.

This fixes the panic for me at least.  Apologies if this is the wrong fix.